### PR TITLE
buy-page

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,3 +1,4 @@
 @import "reset";
 @import "modules/users";
 @import "modules/items";
+@import "modules/buys";

--- a/app/assets/stylesheets/modules/_buys.scss
+++ b/app/assets/stylesheets/modules/_buys.scss
@@ -1,0 +1,165 @@
+* {
+    box-sizing: border-box;
+}
+.single-header{   
+    height: 128px;
+    width: 100%;
+    background-color: whitesmoke;
+    line-height: 128px;
+    text-align: center;
+    a{
+        color: red;
+    }
+}
+.single-main{
+    height: 765.59px;
+    width: 100%;
+    background-color: whitesmoke;
+    text-align: center;
+    &_buy-head{
+        height: 97px;
+        width: 700px;
+        background-color: #ffffff;
+        padding: 32px;
+        font-size: 22px;
+        font-weight: bolder;
+        margin: auto;
+    }
+    &_buy-item{
+        height: 145px;
+        width: 700px;
+        background-color: #ffffff;
+        margin: auto;
+        &_item-box{
+            height: 145px;
+            width: 700px;
+            border-bottom:solid 1px whitesmoke;
+            border-top:solid 1px whitesmoke;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            padding: 32px 48px;
+            &_image{
+                height: 80px;
+                width: 80px;
+                background-color: red;
+            }
+            &_detail{
+                height: 80px;
+                width: 154px;
+                margin: 0 0 0 16px;
+                &_category{
+                    font-size: 14px;
+                    padding: 0 0 8px;
+                }
+                &_fee{
+                    display: flex;
+                    &_price{
+                        font-size: 15px;
+                    }
+                    &_cost{
+                        font-size: 12px;
+                    }
+                }
+            }
+        }
+    }
+    &_buy-content{
+        height: calc(100% - 220px);
+        width: 700px;
+        background-color: #ffffff;
+        margin: auto;
+        &_block{
+            height: 100%;
+            width: 700px;
+            display: flex;
+            justify-content: center;
+            background-color: #ffffff;
+            padding: 32px 16px 48px;
+            &_form{
+                height: 100%;
+                width: 343px;
+                &_submit{
+                    display: flex;
+                    justify-content: space-between;
+                }
+                    &_label{
+                        font-size: 18px;
+                    }
+                    &_cell{
+                        font-size: 30px;
+                    }
+                &_users{
+                    &_point{
+                        text-align: left;
+                        font-size: 14px;
+                        margin: 18px 0px 32px;
+                        color: gray;
+                    }
+                }
+                &_payment{
+                    &_inner{
+                        padding: 32px 0px;
+                        font-size: 14px;
+                        border-bottom:solid 1px whitesmoke;
+                        border-top:solid 1px whitesmoke;
+                        &_top{
+                            text-align: left;
+                        }
+                        &_bottom{
+                            display: flex;
+                            margin: 8px 0 0;
+                            a{
+                                color: #0099E8;
+                            }
+                            &_right{
+                                margin: 0 0 0 4px;
+                            }
+                        }
+                    }
+                    &_user-info{
+                        padding: 32px 0px;
+                        border-bottom:solid 1px whitesmoke;
+                        a{
+                            color: #0099E8;
+                        }
+                        &_over{
+                            display: flex;
+                            justify-content: space-between;
+                            font-size: 14px;
+                            &_right-side{
+                                color: #0099E8;
+                            }
+                        }
+                        &_under{
+                            font-size: 14px;
+                        }
+                    }
+                    &_buy-btn{
+                        height: 50px;
+                        width: 343px;
+                        background-color: #888888;
+                        color: #ffffff;
+                        line-height: 50px;
+                        margin: 32px 0px 0px;
+                    }
+                    &_buy-btn:hover{
+                    box-shadow: none;
+                    color: whitesmoke;
+                    background-color: darkgray;
+                    }
+                }
+            }
+        }
+    }
+}
+.single-footer{
+    height: 220px;
+    width: 100%;
+    background-color: whitesmoke;
+    padding: 40px 0px;
+    &_link-icon{
+        font-size: 12px;
+        text-align: center;
+    }
+}

--- a/app/views/buys/index.html.haml
+++ b/app/views/buys/index.html.haml
@@ -1,0 +1,70 @@
+.single-header
+  .single-header_text-zone
+    mercari
+.single-main
+  .single-main_buy-head
+    購入内容の確認
+  .single-main_buy-item
+    .single-main_buy-item_item-box
+      .single-main_buy-item_item-box_image
+        iamge
+      .single-main_buy-item_item-box_detail
+        .single-main_buy-item_item-box_detail_category
+          メンズ 冬服 まとめて
+        .single-main_buy-item_item-box_detail_fee
+          .single-main_buy-item_item-box_detail_fee_price
+            ¥3,700
+          .single-main_buy-item_item-box_detail_fee_cost
+            （税込）送料込み
+  .single-main_buy-content
+    .single-main_buy-content_block
+      .single-main_buy-content_block_form
+        .single-main_buy-content_block_form_submit
+          .single-main_buy-content_block_form_submit_label
+            支払い金額
+          .single-main_buy-content_block_form_submit_cell
+            ¥3,700
+        .single-main_buy-content_block_form_users
+          .single-main_buy-content_block_form_users_point
+            = form_tag '/sample/confirm', method: :post do
+              - %w(ポイントを使用(所持ポイント:P0)).each do |item|
+                %label
+                  = check_box_tag 'sample_form[colors][]', item
+                  = item
+        .single-main_buy-content_block_form_payment
+          .single-main_buy-content_block_form_payment_inner
+            .single-main_buy-content_block_form_payment_inner_top
+              支払い方法
+            .single-main_buy-content_block_form_payment_inner_bottom
+              .single-main_buy-content_block_form_payment_inner_bottom_left
+                = link_to "#" do
+                  = fa_icon 'plus-circle', class: 'icon'
+              .single-main_buy-content_block_form_payment_inner_bottom_right
+                = link_to "#" do
+                  登録してください
+          .single-main_buy-content_block_form_payment_user-info
+            .single-main_buy-content_block_form_payment_user-info_over
+              .single-main_buy-content_block_form_payment_user-info_over_left-side
+                配送先
+              .single-main_buy-content_block_form_payment_user-info_over_right-side
+                = link_to "#" do
+                  変更する
+            .single-main_buy-content_block_form_payment_user-info_under
+              〒999-9999
+              大阪府 大阪市#区 #丁目 #-#
+              上田 泰史
+          .single-main_buy-content_block_form_payment_buy-btn
+            購入する
+.single-footer
+  .single-footer_link-icon
+    = link_to "#" do
+      プライバシーポリシー
+    = link_to "#" do
+      メルカリ規約
+    = link_to "#" do
+      特定商取引に関する表記
+  .single-footer_link-icon
+    = link_to "#" do
+      = fa_icon 'plus-circle', class: 'icon'
+  .single-footer_link-icon
+    © Mercari, Inc.


### PR DESCRIPTION
# What
フリマアプリの商品購入確認ページのフロント実装
# Why
商品購入ボタンを押した際に確認ができるページを作るため

headerとfooterははマークアップが一通り終了してから追加します

https://i.gyazo.com/bba53cc83c030d5be113870329fd8a98.png
https://i.gyazo.com/19eae9343bf68fdeff796adc9ac63b26.png