### PR TITLE
商品詳細ページ

### DIFF
--- a/app/assets/stylesheets/modules/_product_detail_page.scss
+++ b/app/assets/stylesheets/modules/_product_detail_page.scss
@@ -81,7 +81,6 @@ ul {
   margin-block-end: 1em;
   margin-inline-start: 0px;
   margin-inline-end: 0px;
-  padding-inline-start: 40px;
 }
 
 .item-box-container {
@@ -103,8 +102,8 @@ ul {
     background: #fafafa;
     padding: 10px;
     img {
-      max-width: 100%;
-      max-height: 100%;
+      max-width: 560px;
+      height: 430px;
     }
   }
   .item-image {
@@ -113,7 +112,7 @@ ul {
       img {
         max-width: 100px;
         max-height: 100px;
-        margin: 10px 50px 0 0;
+        margin: 10px 15px 0 0;
         background: #fafafa;
       }
     }
@@ -152,6 +151,7 @@ ul {
     padding: 32px 0 0;
     .item-discription-inner {
       white-space: pre-wrap;
+      margin-bottom: 15px;
     }
   }
   .optional-area {
@@ -231,5 +231,43 @@ ul {
     color:$blue;
     font-weight: bold;
     font-size: 22px;
+  }
+}
+.no-acount{
+  text-align: center;
+  margin-top: 20px;
+}
+.my-item{
+  margin: 10px auto;
+  padding: 10px;
+  display: flex;
+  justify-content: space-around;
+  .item-edit-btn {
+    display: block;
+    border-radius: 40px;
+    background: #ea352d;
+    color: #fff;
+    text-align: center;
+    font-weight: 600;
+    transition: all ease-out .3s;
+    width: 30%;
+    height: 60px;
+    text-align: center;
+    font-size: 24px;
+    line-height: 60px;
+  }
+  .item-delete-btn {
+    display: block;
+    background: royalblue;
+    border-radius: 40px;
+    color: #fff;
+    text-align: center;
+    font-weight: 600;
+    transition: all ease-out .3s;
+    width: 30%;
+    height: 60px;
+    text-align: center;
+    font-size: 24px;
+    line-height: 60px;
   }
 }

--- a/app/assets/stylesheets/modules/_top.scss
+++ b/app/assets/stylesheets/modules/_top.scss
@@ -195,13 +195,12 @@ li {
         padding: 60px 0 ;
       }
       &__lists {
-        width: 780px;
-        height: 550px;
+        width: 760px;
+        height: 580px;
         display: flex;
         flex-wrap: wrap;
         margin:26px auto;
         overflow: scroll;
-        justify-content: space-between;
         ul {
           padding: 0;
           margin: 0;

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -31,6 +31,7 @@ class ItemsController < ApplicationController
   end
 
   def show
+    @item = Item.find(params[:id])
   end
 
 

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -87,7 +87,7 @@
         - @item.each do |item|
           - if item.sold == "sale"
             .body__center__items__lists__list
-              = link_to root_path do
+              = link_to item_path(item.id) do
                 .body__center__items__lists__list__picture
                   = image_tag item.images.first.image.url, class:"body__center__items__lists__list__picture", alt:""
                 .body__center__items__lists__list__info

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -1,65 +1,63 @@
 %section.item-box-container
   %h1.item-name 
-    【値下げしました】ぼくのりりっくのぼうよみ 没落 CD
+    = @item.name
   .item-photo
-    = image_tag "/assets/974762.jpg", alt: "メイン画像です"
+    = image_tag @item.images.first.image.url
   .item-image
-    %ul.hoge 
-      %li
-        = image_tag "/assets/atm.png", alt: "サブ画像です"
-      %li
-        = image_tag "/assets/kabipan.png", alt: "サブ画像です"
-      %li
-        = image_tag "/assets/kabipan.png", alt: "サブ画像です"
+    %ul.hoge
+      - if @item.images.count >= 2
+        - @item.images.each do |image|
+          %li
+            = image_tag image.image.url
   .item-price-box
     %span.item-price
-      ¥1,222
+      ¥
+      = @item.value
     %span.item-tax
       (税込み)
     %span.item-shipping-fee
       送料込み
-    = link_to "購入画面に進む", "#", class: "item-buy-btn"
   .item-discription
     %p.item-discription-inner
-      数回聴いたのみで綺麗です。
-      没落の外ケースは小さな擦れ傷がありますが、CDは見受けられる傷等ありません。
-      （その為"やや傷や汚れあり設定"にしています）
-      再生問題なく行えます。
+      商品説明
+      %br
+      = @item.info
     %table.item-detail-table
       %tbody
         %tr
           %th
             出品者
           %td
-            = link_to "るるかさん", "#" 
+            = @item.user.nickname 
         %tr            
           %th
             カテゴリー
           %td
-            = link_to "本・音楽・ゲーム", "#" 
-            = link_to "CD", "#"
-            = link_to "邦楽", "#"
+            = @item.category.name
         %tr            
           %th
             ブランド
           %td
-            %a(href="#")
+            = @item.brand.name
           %div      
         %tr            
           %th
             商品の状態
           %td
-            やや傷や汚れあり     
+            - if @item.status == "clean"
+              新品
+            - elsif @item.status == "beauty"
+              美品
+            - else
+              汚い
         %tr            
           %th
             配送料の負担
           %td
-            送料込み（出品者負担）
-        %tr            
-          %th
-            配送の方法
-          %td
-            ゆうゆうメルカリ便
+            - if @item.shipment.delivery_burden == "my"
+              送料込み（出品者負担）
+            - else
+              着払い（購入者負担）
   .optional-area
     .optional-btn-left
       = icon('fa', 'star')
@@ -67,6 +65,16 @@
     .optional
       .optional-btn-right
         = link_to "不適切な商品の通報", "#"
+  - if user_signed_in?
+    - if current_user.id == @item.user_id
+      .my-item
+        = link_to "編集", "#", class: "item-edit-btn"
+        = link_to "削除", "#", class: "item-delete-btn"
+    - else
+      = link_to "購入画面に進む", "#", class: "item-buy-btn"
+  - else
+    .no-acount
+      購入するにはアカウントが必要です。
 .new-comment
   %textarea.comment(name="")
   %p.notice-msg

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
     resources :cards 
     resources :buys
   end
-  resources :items, only: [:new, :create] do
+  resources :items, only: [:new, :create, :show] do
     collection do
       post 'purchase'
       get 'get_category_children', defaults: { format: 'json' }


### PR DESCRIPTION
#WHAT
商品詳細ページの実装。
トップページに出品中の商品を表示させたあとの作業です。
要素全体をクリックすればその商品の詳細ページに飛べるようにしました。
ログイン中か否か→自分の出品した商品か否かでそれぞれ表示が変わります。

①　トップページで商品一覧の確認。クリックすると飛べます。
<img width="933" alt="スクリーンショット 2020-05-04 20 02 51" src="https://user-images.githubusercontent.com/62457945/80959882-b2fafb80-8e42-11ea-98e0-a40a6644b7a9.png">
②　ログインしていない場合,自分の商品である場合,他人の商品である場合の表示です。
<img width="950" alt="スクリーンショット 2020-05-04 20 00 22" src="https://user-images.githubusercontent.com/62457945/80959963-d45be780-8e42-11ea-9a91-1188b63b46ee.png">
<img width="981" alt="スクリーンショット 2020-05-04 19 59 16" src="https://user-images.githubusercontent.com/62457945/80959967-d9b93200-8e42-11ea-9bb7-50bc8b5a977f.png">
<img width="969" alt="スクリーンショット 2020-05-04 19 59 47" src="https://user-images.githubusercontent.com/62457945/80959974-dd4cb900-8e42-11ea-98f9-88293678165e.png">
③　show.html.haml　の主な変更点です。
<img width="623" alt="スクリーンショット 2020-05-04 20 00 52" src="https://user-images.githubusercontent.com/62457945/80960035-fce3e180-8e42-11ea-9bc5-57de7b823449.png">

#WHY
チーム全員に共有済です。
メンターにレビューを依頼し改修していくためのリクエストです。



